### PR TITLE
Fixed error messages when calling rake

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,20 +7,22 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.3)
+    rake (0.9.2.2)
     rr (1.0.4)
-    rspec (2.9.0)
-      rspec-core (~> 2.9.0)
-      rspec-expectations (~> 2.9.0)
-      rspec-mocks (~> 2.9.0)
-    rspec-core (2.9.0)
-    rspec-expectations (2.9.1)
+    rspec (2.10.0)
+      rspec-core (~> 2.10.0)
+      rspec-expectations (~> 2.10.0)
+      rspec-mocks (~> 2.10.0)
+    rspec-core (2.10.0)
+    rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
-    rspec-mocks (2.9.0)
+    rspec-mocks (2.10.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bbcoder!
+  rake
   rr
   rspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,13 +4,14 @@ Bundler.setup
 require "rspec"
 require "rspec/core/rake_task"
 
-Rspec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec)
 
 gemspec = eval(File.read(File.join(Dir.pwd, "bbcoder.gemspec")))
 
 task :build => "#{gemspec.full_name}.gem"
 
 task :test => :spec
+task :default => :spec
 
 file "#{gemspec.full_name}.gem" => gemspec.files + ["bbcoder.gemspec"] do
   system "gem build bbcoder.gemspec"

--- a/bbcoder.gemspec
+++ b/bbcoder.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rr'
 end


### PR DESCRIPTION
I got lots of error messages when calling rake:

```
$ rake -T
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/version.rb:2: warning: already initialized constant VERSION
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/version.rb:5: warning: already initialized constant MAJOR
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/version.rb:5: warning: already initialized constant MINOR
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/version.rb:5: warning: already initialized constant BUILD
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/version.rb:6: warning: already initialized constant NUMBERS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake.rb:27: warning: already initialized constant RAKEVERSION
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/early_time.rb:17: warning: already initialized constant EARLY
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/alt_system.rb:32: warning: already initialized constant WINDOWS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:31: warning: already initialized constant DEFAULT_RAKEFILES
WARNING: Possible conflict with Rake extension: String#ext already exists
WARNING: Possible conflict with Rake extension: String#pathmap already exists
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/task_arguments.rb:77: warning: already initialized constant EMPTY_TASK_ARGS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/invocation_chain.rb:49: warning: already initialized constant EMPTY
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_utils.rb:9: warning: already initialized constant RUBY
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_utils.rb:86: warning: already initialized constant LN_SUPPORTED
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_utils_ext.rb:16: warning: already initialized constant DEFAULT
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/dsl_definition.rb:150: warning: already initialized constant DeprecatedCommands
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:44: warning: already initialized constant ARRAY_METHODS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:47: warning: already initialized constant MUST_DEFINE
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:51: warning: already initialized constant MUST_NOT_DEFINE
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:55: warning: already initialized constant SPECIAL_RETURN
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:61: warning: already initialized constant DELEGATING_METHODS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:364: warning: already initialized constant DEFAULT_IGNORE_PATTERNS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/file_list.rb:370: warning: already initialized constant DEFAULT_IGNORE_PROCS
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake.rb:68: warning: already initialized constant FileList
/home/igel/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake.rb:69: warning: already initialized constant RakeFileUtils
*****************************************************************
DEPRECATION WARNING: you are using a deprecated constant that will
be removed from a future version of RSpec.

/home/igel/.rvm/gems/ruby-1.9.3-p194@global/gems/rake-0.9.2.2/lib/rake/rake_module.rb:25:in `load'

* Rspec is deprecated.
* RSpec is the new top-level module in RSpec-2
*****************************************************************
```

Also:
- Upgraded rspec to 2.10.0
- Mapped the default rake task to spec
