### PR TITLE
Update rubygems source. (use https)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     bbcoder (1.0.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     diff-lcs (1.1.3)
     rake (0.9.2.2)


### PR DESCRIPTION
The source location for rubygems should point to rubygems.org using the HTTPS protocol.

It spits out a warning and nothing will break without the change but, ideally it uses the more secure route.
